### PR TITLE
Fix bug in purge_detail()

### DIFF
--- a/src/misc/utils.R
+++ b/src/misc/utils.R
@@ -63,15 +63,29 @@ get_vector = function(df, name) {
     return()
 }
 
+
+
 purge_detail = function() {
-  for(behavior in c("static", "conventional")){
-    unlink(
-      file.path(globals$output_root,
-                scenario_id,
-                behavior,
-                "detail/*"
+  
+  #----------------------------------------------------------------------------
+  # Deletes all output stored in /detail, which contains tax unit microdata 
+  # detail files.
+  # 
+  # Parameters: none
+  #
+  # Returns: void
+  #----------------------------------------------------------------------------
+  
+  for (scenario_id in globals$runtime_args$ID) {
+    for (behavior in c("static", "conventional")) {
+      unlink(
+        file.path(globals$output_root,
+                  scenario_id,
+                  behavior,
+                  "detail/*"
+        )
       )
-    )
+    }
   }
 }
 


### PR DESCRIPTION
`purge_detail()` references a `scenario_id` variable which is not actually defined at the point of deletion. Post-processing occurs outside of the scenario loop. Fixed this by wrapping existing function logic in a loop over `globals$runtime_args$ID`, which is a vector of all scenarios IDs.
