### PR TITLE
Add initial catalog file

### DIFF
--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -1,0 +1,24 @@
+{
+    "name": "Tax-Simulator",
+    "img": "",
+    "banner_title": "Tax-Simulator",
+    "banner_subtitle": "Microsimulation model of the US federal tax system",
+    "detailed_description": "Microsimulation model of the US federal tax system",
+    "policy_area": "Tax Microsimulation, Revenue Estimation, Distributional Analysis",
+    "geography": "United States",
+    "language": "R",
+    "maintainers": [
+        {
+            "name": "John Ricco",
+            "image": "https://avatars.githubusercontent.com/u/140451358?v=4",
+            "link": "https://github.com/ricco-budget-lab"
+        }
+    ],
+    "links": {
+      "code_repository": "https://github.com/Budget-Lab-Yale/Tax-Simulator",
+      "user_documentation": "https://github.com/Budget-Lab-Yale/Tax-Simulator",
+      "contributor_documentation": "https://github.com/Budget-Lab-Yale/Tax-Simulator",
+      "webapp": "",
+      "recent_changes": ""
+    }
+}

--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -1,6 +1,6 @@
 {
     "name": "Tax-Simulator",
-    "img": "",
+    "img": "https://pbs.twimg.com/profile_images/1785777668052353024/d3MFlcWd_400x400.png",
     "banner_title": "Tax-Simulator",
     "banner_subtitle": "Microsimulation model of the US federal tax system",
     "detailed_description": "Microsimulation model of the US federal tax system",


### PR DESCRIPTION
This PR adds an initial JSON file to list Tax-Simulator in the [incubating projects page](http://pslmodels.org/Incubating/index.html) on [PSLmodels.org](http://pslmodels.org).  Once other [PSL criteria](http://pslmodels.org/Catalog/library_criteria.html) are checked off, this project would be moved to the cataloged projects page.