### PR TITLE
Drop NA-baseline-income rows in horizontal equity table

### DIFF
--- a/src/data/post_processing/horizontal.R
+++ b/src/data/post_processing/horizontal.R
@@ -54,6 +54,10 @@ build_horizontal_table = function(id) {
         by = 'id'
       ) %>%
 
+      # Drop records whose baseline counterpart was filtered out (e.g. expanded_inc
+      # flipped sign under the reform); they can't be ranked against baseline.
+      filter(!is.na(inc)) %>%
+
       # Compute effective tax rate and grouping variables
       mutate(
         married = as.integer(filing_status == 2),


### PR DESCRIPTION
## Summary
- `build_horizontal_table()` was crashing on reforms with large employer-side payroll changes (e.g. uncapping OASDI) with `Error in approx(): zero non-NA points`.
- Root cause: `expanded_inc` includes `liab_pr_er`, so a reform can flip a record's `expanded_inc` sign relative to baseline. The scenario record passes the `expanded_inc > 0` filter, but its baseline counterpart was filtered out. The `left_join` to baseline income then leaves `inc = NA`, `cut()` produces an `inc_pctile = NA` group, and `Hmisc::wtd.quantile()` blows up on the all-NA `etr` values.
- Fix: drop `is.na(inc)` rows after the join — they can't be ranked against baseline anyway.

Reported by Mark Keightley (CRS) while running an SS no-cap scenario; only affects the horizontal equity supplemental file, not totals/deltas/distribution.

## Test plan
- [ ] Re-run an SS no-cap scenario (employer + employee) and confirm `horizontal.csv` is produced without error.
- [ ] Re-run an existing reform that previously succeeded and confirm `horizontal.csv` is unchanged (the filter is a no-op when no records flip sign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)